### PR TITLE
XPTL - Wire up List Height option

### DIFF
--- a/source/nuComponents.DataTypes/XPathTemplatableList/Editor.css
+++ b/source/nuComponents.DataTypes/XPathTemplatableList/Editor.css
@@ -100,7 +100,10 @@
 
 .xpath-templatable-list .selectable {
     float: left;
-    /*overflow-y: scroll;*/
+}
+
+.xpath-templatable-list .selectable.fixed-height {
+    overflow-y: auto;
 }
 
 .xpath-templatable-list .selectable .markup {

--- a/source/nuComponents.DataTypes/XPathTemplatableList/Editor.html
+++ b/source/nuComponents.DataTypes/XPathTemplatableList/Editor.html
@@ -3,7 +3,11 @@
     <!--<link rel="stylesheet" type="text/css" ng-if="model.config.CssFile" ng-href="{{ model.config.CssFile }}" /> TODO: move this to controller and use assetsService -->
 
     <!-- selectable -->
-    <ul class="selectable" ng-model="selectableOptions">
+    <ul class="selectable"
+        ng-model="selectableOptions"
+        ng-class="{'fixed-height':model.config.listHeight > 0 }"
+        ng-style="{'max-height': (model.config.listHeight > 0 ? model.config.listHeight + 'px' : '') }">
+
         <li ng-repeat="option in selectableOptions"
             ng-hide="model.config.hideUsed == '1' && !isSelectable(option)"
             ng-class="{lit:lit, disabled:!isValidSelection(option), used:isUsed(option)}">


### PR DESCRIPTION
This wires up the "List Height" PreValue - it was there but didn't look to be hooked up yet (apologies if I missed something!)

Preview when "List Height" is set to `200`
![xptl-200px](https://cloud.githubusercontent.com/assets/1396376/2869652/e9f015b4-d280-11e3-84cd-9458bf22906d.png)

The scrollbar should remove it self (`overflow-y: auto`) automatically when it's not needed:
![xptl-200px-2](https://cloud.githubusercontent.com/assets/1396376/2869653/ef2ca31c-d280-11e3-9a79-274a30c11bd3.png)

When left blank or `0`, the list will be fluid as is now.
