### PR TITLE
Added parentId to the DataSourceResource.js > getEditorDataItems

### DIFF
--- a/source/nuPickers/Shared/DataSource/DataSourceResource.js
+++ b/source/nuPickers/Shared/DataSource/DataSourceResource.js
@@ -14,6 +14,7 @@ angular.module('umbraco.resources')
                         url: 'backoffice/nuPickers/' + model.config.dataSource.apiController + '/GetEditorDataItems',
                         params: {
                             'contextId': editorState.current.id,
+                            'parentId': editorState.current.parentId,
                             'propertyAlias' : model.alias
                         },
                         data: {

--- a/source/nuPickers/Shared/DotNetDataSource/DotNetDataSource.cs
+++ b/source/nuPickers/Shared/DotNetDataSource/DotNetDataSource.cs
@@ -21,7 +21,7 @@ namespace nuPickers.Shared.DotNetDataSource
         [DefaultValue(false)]
         internal bool HandledTypeahead { get; set; }
 
-        public IEnumerable<EditorDataItem> GetEditorDataItems(int contextId)
+        public IEnumerable<EditorDataItem> GetEditorDataItems(int contextId, int parentId)
         {
             IEnumerable<EditorDataItem> editorDataItems = Enumerable.Empty<EditorDataItem>();
 

--- a/source/nuPickers/Shared/DotNetDataSource/DotNetDataSourceApiController.cs
+++ b/source/nuPickers/Shared/DotNetDataSource/DotNetDataSourceApiController.cs
@@ -67,12 +67,12 @@ namespace nuPickers.Shared.DotNetDataSource
 
 
         [HttpPost]
-        public IEnumerable<EditorDataItem> GetEditorDataItems([FromUri] int contextId, [FromUri] string propertyAlias, [FromBody] dynamic data)
+        public IEnumerable<EditorDataItem> GetEditorDataItems([FromUri] int contextId, [FromUri] int parentId, [FromUri] string propertyAlias, [FromBody] dynamic data)
         {
             DotNetDataSource dotNetDataSource = ((JObject)data.config.dataSource).ToObject<DotNetDataSource>();
             dotNetDataSource.Typeahead = (string)data.typeahead;
 
-            IEnumerable<EditorDataItem> editorDataItems = dotNetDataSource.GetEditorDataItems(contextId).ToList();
+            IEnumerable<EditorDataItem> editorDataItems = dotNetDataSource.GetEditorDataItems(contextId, parentId).ToList();
 
             CustomLabel customLabel = new CustomLabel((string)data.config.customLabel, contextId, propertyAlias);
 

--- a/source/nuPickers/Shared/EnumDataSource/EnumDataSourceApiController.cs
+++ b/source/nuPickers/Shared/EnumDataSource/EnumDataSourceApiController.cs
@@ -37,7 +37,7 @@
         }
 
         [HttpPost]
-        public IEnumerable<EditorDataItem> GetEditorDataItems([FromUri] int contextId, [FromUri] string propertyAlias, [FromBody] dynamic data)
+        public IEnumerable<EditorDataItem> GetEditorDataItems([FromUri] int contextId, [FromUri] int parentId, [FromUri] string propertyAlias, [FromBody] dynamic data)
         {
             EnumDataSource enumDataSource = ((JObject)data.config.dataSource).ToObject<EnumDataSource>();
 

--- a/source/nuPickers/Shared/JsonDataSource/JsonDataSource.cs
+++ b/source/nuPickers/Shared/JsonDataSource/JsonDataSource.cs
@@ -18,7 +18,7 @@ namespace nuPickers.Shared.JsonDataSource
 
         public string LabelJsonPath { get; set; }
 
-        public IEnumerable<EditorDataItem> GetEditorDataItems(int contextId)
+        public IEnumerable<EditorDataItem> GetEditorDataItems(int contextId, int parentId)
         {
 
             List<EditorDataItem> editorDataItems = new List<EditorDataItem>();

--- a/source/nuPickers/Shared/JsonDataSource/JsonDataSourceApiController.cs
+++ b/source/nuPickers/Shared/JsonDataSource/JsonDataSourceApiController.cs
@@ -14,11 +14,11 @@ namespace nuPickers.Shared.JsonDataSource
     public class JsonDataSourceApiController : UmbracoAuthorizedJsonController
     {
         [HttpPost]
-        public IEnumerable<EditorDataItem> GetEditorDataItems([FromUri] int contextId, [FromUri] string propertyAlias, [FromBody] dynamic data)
+        public IEnumerable<EditorDataItem> GetEditorDataItems([FromUri] int contextId, [FromUri] int parentId, [FromUri] string propertyAlias, [FromBody] dynamic data)
         {
             JsonDataSource jsonDataSource = ((JObject)data.config.dataSource).ToObject<JsonDataSource>();
 
-            IEnumerable<EditorDataItem> editorDataItems = jsonDataSource.GetEditorDataItems(contextId);
+            IEnumerable<EditorDataItem> editorDataItems = jsonDataSource.GetEditorDataItems(contextId, parentId);
 
             CustomLabel customLabel = new CustomLabel((string)data.config.customLabel, contextId, propertyAlias);
             TypeaheadListPicker typeaheadListPicker = new TypeaheadListPicker((string)data.typeahead);

--- a/source/nuPickers/Shared/LuceneDataSource/LuceneDataSource.cs
+++ b/source/nuPickers/Shared/LuceneDataSource/LuceneDataSource.cs
@@ -17,7 +17,7 @@ namespace nuPickers.Shared.LuceneDataSource
         
         public string LabelField { get; set; }
 
-        public IEnumerable<EditorDataItem> GetEditorDataItems(int contextId)
+        public IEnumerable<EditorDataItem> GetEditorDataItems(int contextId, int parentId)
         {
             List<EditorDataItem> editorDataItems = new List<EditorDataItem>();
 

--- a/source/nuPickers/Shared/LuceneDataSource/LuceneDataSourceApiController.cs
+++ b/source/nuPickers/Shared/LuceneDataSource/LuceneDataSourceApiController.cs
@@ -21,11 +21,11 @@ namespace nuPickers.Shared.LuceneDataSource
         }
 
         [HttpPost]
-        public IEnumerable<EditorDataItem> GetEditorDataItems([FromUri] int contextId, [FromUri] string propertyAlias, [FromBody] dynamic data)
+        public IEnumerable<EditorDataItem> GetEditorDataItems([FromUri] int contextId, [FromUri] int parentId, [FromUri] string propertyAlias, [FromBody] dynamic data)
         {
             LuceneDataSource luceneDataSource = ((JObject)data.config.dataSource).ToObject<LuceneDataSource>();
 
-            IEnumerable<EditorDataItem> editorDataItems = luceneDataSource.GetEditorDataItems(contextId);
+            IEnumerable<EditorDataItem> editorDataItems = luceneDataSource.GetEditorDataItems(contextId, parentId);
 
             CustomLabel customLabel = new CustomLabel((string)data.config.customLabel, contextId, propertyAlias);
             TypeaheadListPicker typeaheadListPicker = new TypeaheadListPicker((string)data.typeahead);

--- a/source/nuPickers/Shared/RelationDataSource/RelationDataSourceApiController.cs
+++ b/source/nuPickers/Shared/RelationDataSource/RelationDataSourceApiController.cs
@@ -28,7 +28,7 @@ namespace nuPickers.Shared.RelationDataSource
 
 
         [HttpPost]
-        public IEnumerable<EditorDataItem> GetEditorDataItems([FromUri] int contextId, [FromUri] string propertyAlias, [FromBody] dynamic data)
+        public IEnumerable<EditorDataItem> GetEditorDataItems([FromUri] int contextId, [FromUri] int parentId, [FromUri] string propertyAlias, [FromBody] dynamic data)
         {
             IEnumerable<EditorDataItem> editorDataItems = RelationType.GetByAlias((string)data.config.dataSource.relationType)
                                                                                 .GetRelations(contextId)

--- a/source/nuPickers/Shared/RelationMapping/RelationMappingApiController.cs
+++ b/source/nuPickers/Shared/RelationMapping/RelationMappingApiController.cs
@@ -63,7 +63,7 @@
         }        
 
         [HttpPost]
-        public void UpdateRelationMapping([FromUri] int contextId, [FromUri] string propertyAlias, [FromUri] string relationTypeAlias, [FromUri] bool relationsOnly, [FromBody] dynamic data)
+        public void UpdateRelationMapping([FromUri] int contextId, [FromUri] int parentId, [FromUri] string propertyAlias, [FromUri] string relationTypeAlias, [FromUri] bool relationsOnly, [FromBody] dynamic data)
         {
             IRelationType relationType = ApplicationContext.Services.RelationService.GetRelationTypeByAlias(relationTypeAlias);
 

--- a/source/nuPickers/Shared/SqlDataSource/SqlDataSource.cs
+++ b/source/nuPickers/Shared/SqlDataSource/SqlDataSource.cs
@@ -14,7 +14,7 @@ namespace nuPickers.Shared.SqlDataSource
 
         public string Typeahead { get; set; } // the value supplied by the user - the current typeahead text
 
-        public IEnumerable<EditorDataItem> GetEditorDataItems(int contextId) // supply option typeahead param
+        public IEnumerable<EditorDataItem> GetEditorDataItems(int contextId, int parentId) // supply option typeahead param
         {
             List<EditorDataItem> editorDataItems = new List<EditorDataItem>();
 
@@ -24,10 +24,11 @@ namespace nuPickers.Shared.SqlDataSource
             {
                 string sql = Regex.Replace(this.SqlExpression, "\n|\r", " ")
                              .Replace("@contextId", "@0")
-                             .Replace("@typeahead", "@1");
+                             .Replace("@parentId", "@1")
+                             .Replace("@typeahead", "@2");
 
 
-                editorDataItems = database.Fetch<EditorDataItem>(sql, contextId, this.Typeahead);
+                editorDataItems = database.Fetch<EditorDataItem>(sql, contextId, parentId, this.Typeahead);
             }
 
             return editorDataItems;

--- a/source/nuPickers/Shared/SqlDataSource/SqlDataSourceApiController.cs
+++ b/source/nuPickers/Shared/SqlDataSource/SqlDataSourceApiController.cs
@@ -26,12 +26,12 @@
         }
 
         [HttpPost]
-        public IEnumerable<EditorDataItem> GetEditorDataItems([FromUri] int contextId, [FromUri] string propertyAlias, [FromBody] dynamic data)
+        public IEnumerable<EditorDataItem> GetEditorDataItems([FromUri] int contextId, [FromUri] int parentId, [FromUri] string propertyAlias, [FromBody] dynamic data)
         {
             SqlDataSource sqlDataSource = ((JObject)data.config.dataSource).ToObject<SqlDataSource>();
             sqlDataSource.Typeahead = (string)data.typeahead;
 
-            IEnumerable<EditorDataItem> editorDataItems = sqlDataSource.GetEditorDataItems(contextId);
+            IEnumerable<EditorDataItem> editorDataItems = sqlDataSource.GetEditorDataItems(contextId, parentId);
 
             CustomLabel customLabel = new CustomLabel((string)data.config.customLabel, contextId, propertyAlias);
             TypeaheadListPicker typeaheadListPicker = new TypeaheadListPicker((string)data.typeahead);

--- a/source/nuPickers/Shared/XmlDataSource/XmlDataSource.cs
+++ b/source/nuPickers/Shared/XmlDataSource/XmlDataSource.cs
@@ -21,7 +21,7 @@ namespace nuPickers.Shared.XmlDataSource
         
         public string LabelXPath { get; set; }
 
-        public IEnumerable<EditorDataItem> GetEditorDataItems(int contextId)
+        public IEnumerable<EditorDataItem> GetEditorDataItems(int contextId, int parentId)
         {
             XmlDocument xmlDocument;
             List<EditorDataItem> editorDataItems = new List<EditorDataItem>();

--- a/source/nuPickers/Shared/XmlDataSource/XmlDataSourceApiController.cs
+++ b/source/nuPickers/Shared/XmlDataSource/XmlDataSourceApiController.cs
@@ -14,11 +14,11 @@ namespace nuPickers.Shared.XmlDataSource
     public class XmlDataSourceApiController : UmbracoAuthorizedJsonController
     {
         [HttpPost]
-        public IEnumerable<EditorDataItem> GetEditorDataItems([FromUri] int contextId, [FromUri] string propertyAlias, [FromBody] dynamic data)
+        public IEnumerable<EditorDataItem> GetEditorDataItems([FromUri] int contextId, [FromUri] int parentId, [FromUri] string propertyAlias, [FromBody] dynamic data)
         {
             XmlDataSource xmlDataSource = ((JObject)data.config.dataSource).ToObject<XmlDataSource>();
 
-            IEnumerable<EditorDataItem> editorDataItems = xmlDataSource.GetEditorDataItems(contextId);
+            IEnumerable<EditorDataItem> editorDataItems = xmlDataSource.GetEditorDataItems(contextId, parentId);
 
             CustomLabel customLabel = new CustomLabel((string)data.config.customLabel, contextId, propertyAlias);
             TypeaheadListPicker typeaheadListPicker = new TypeaheadListPicker((string)data.typeahead);


### PR DESCRIPTION
Allows use of the parentId in GetEditorDataItems calls as it is now passed in to the api controllers. ContextId is not available when you are creating a new node since it hasn't yet been saved.

If you are wondering why, I have a case where the query is dependent on the new nodes location. Here is an example, that doesn't really match my case but the idea is there:

Glass
--Opaque Glass
--[NEW NODE CREATED HERE]
Metal
--Gold
Properties
--Glass
----Thickness
----Clarity
--Metal
----Conductivity
----Malleability

If I create a new node at the location described above. We want a pull down to show ['Thickness', 'Clarity']. That same document type when created under Metal would have that property show ['Conductivity', 'Malleability']

For this case it might make sense to have two different document types but in our case the items have many of these properties and it is silly to have to maintain different property types in two document types.