### PR TITLE
Specify namespace to search for the controller that matches the request

### DIFF
--- a/source/nuPickers/EmbeddedResourceStartup.cs
+++ b/source/nuPickers/EmbeddedResourceStartup.cs
@@ -17,7 +17,9 @@
                 {
                     controller = "EmbeddedResource",
                     action = "GetSharedResource"
-                });
+                },
+                namespaces: new[] { "nuPickers" }
+            );
         }
     }
 }


### PR DESCRIPTION
Specify namespace to search for the controller in order to avoid a "Multiple types were found that match the controller named" exception when another package also contains a controller named 'EmbeddedResource'.