### PR TITLE
Dll load error in Helper.GetAssembly

### DIFF
--- a/source/nuPickers/Helper.cs
+++ b/source/nuPickers/Helper.cs
@@ -44,8 +44,15 @@ namespace nuPickers
             string assemblyFilePath = HostingEnvironment.MapPath(string.Concat("~/bin/", assemblyName));
             if (!string.IsNullOrEmpty(assemblyFilePath))
             {
-                // HACK: http://stackoverflow.com/questions/1031431/system-reflection-assembly-loadfile-locks-file
-                return Assembly.Load(File.ReadAllBytes(assemblyFilePath));
+                try
+                {
+                    // HACK: http://stackoverflow.com/questions/1031431/system-reflection-assembly-loadfile-locks-file
+                    return Assembly.Load(File.ReadAllBytes(assemblyFilePath));
+                }
+                catch(Exception e)
+                {
+                    return null;
+                }
             }
 
             return null;

--- a/source/nuPickers/Shared/DotNetDataSource/DotNetDataSourceApiController.cs
+++ b/source/nuPickers/Shared/DotNetDataSource/DotNetDataSourceApiController.cs
@@ -20,7 +20,7 @@ namespace nuPickers.Shared.DotNetDataSource
         public IEnumerable<object> GetAssemblyNames()
         {
             return Helper.GetAssemblyNames()
-                            .Where(x => Helper.GetAssembly(x).GetTypes().Any(y => typeof(IDotNetDataSource).IsAssignableFrom(y)));
+                            .Where(x => Helper.GetAssembly(x) != null && Helper.GetAssembly(x).GetTypes().Any(y => typeof(IDotNetDataSource).IsAssignableFrom(y)));
         }
 
         public IEnumerable<object> GetClassNames([FromUri]string assemblyName)


### PR DESCRIPTION
Added try-catch statement to Assembly.Load method.
Assembly.Load caused error during loading ApplicationInsights (Azure)
dlls.
Added null-check to DotNetDataSourceApiController.GetAssemblyNames.