### PR TITLE
Overrides the `ToString` method on `Picker`

### DIFF
--- a/source/nuPickers/Picker.cs
+++ b/source/nuPickers/Picker.cs
@@ -228,5 +228,19 @@
 
             return enums;
         }
+
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            if (this.SavedValue != null)
+                return this.SavedValue.ToString();
+
+            return base.ToString();
+        }
     }
 }


### PR DESCRIPTION
Previously this would return the name of the type, e.g. "nuPickers.Picker", now it would return the value of `SavedValue`.

This means that if we use `Model.Content.GetPropertyValue<string>("alias")` in our code, we would get the raw value, and not the `Picker` object itself.

This PR attempts to resolve issue #56.  I'm not 100% sure whether this would be considered a breaking-change or not?