### PR TITLE
Adds support for embedded resources

### DIFF
--- a/source/nuPickers.sln
+++ b/source/nuPickers.sln
@@ -22,6 +22,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "package", "package", "{A763
 		..\package\Test.bat = ..\package\Test.bat
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nuWebTestSite", "nuWebTestSite\nuWebTestSite.csproj", "{866E1649-BC20-427C-A00B-6D340639EFEA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,10 @@ Global
 		{FB665B93-6D85-4040-AB20-003B728E3ACA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FB665B93-6D85-4040-AB20-003B728E3ACA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FB665B93-6D85-4040-AB20-003B728E3ACA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{866E1649-BC20-427C-A00B-6D340639EFEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{866E1649-BC20-427C-A00B-6D340639EFEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{866E1649-BC20-427C-A00B-6D340639EFEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{866E1649-BC20-427C-A00B-6D340639EFEA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/source/nuPickers/EmbeddedResourceController.cs
+++ b/source/nuPickers/EmbeddedResourceController.cs
@@ -1,7 +1,5 @@
 ﻿namespace nuPickers
 {
-    using System.Globalization;
-    using System.Linq;
     using System.Web;
     using System.Web.Mvc;
 
@@ -12,37 +10,18 @@
     {
         public ActionResult GetSharedResource(string folder, string file)
         {
-            var resource = this.GetResource("nuPickers.Shared." + folder + "." + file);
-
-            if (resource != null)
+            string resourceName;
+            var resourceStream = EmbeddedResourceHelper.GetResource("nuPickers.Shared." + folder + "." + file, out resourceName);
+            
+            if (resourceStream != null)
             {
-                return resource;
+                return new FileStreamResult(resourceStream, GetMimeType(resourceName)); ;
             }
 
             return this.HttpNotFound();
         }
 
-        private FileStreamResult GetResource(string resource)
-        {
-            // get this assembly
-            var assembly = typeof(EmbeddedResourceController).Assembly;
-
-            // find the resource name not case sensitive
-            var resourceName =
-                assembly.GetManifestResourceNames()
-                    .FirstOrDefault(
-                        x => x.ToLower(CultureInfo.InvariantCulture) == resource.ToLower(CultureInfo.InvariantCulture));
-
-            if (resourceName != null)
-            {
-                return new FileStreamResult(
-                                assembly.GetManifestResourceStream(resourceName),
-                                this.GetMimeType(resourceName));
-            }
-
-            return null;
-        }
-
+        
         private string GetMimeType(string resource)
         {
             var mimeType = MimeMapping.GetMimeMapping(resource);

--- a/source/nuPickers/EmbeddedResourceHelper.cs
+++ b/source/nuPickers/EmbeddedResourceHelper.cs
@@ -1,0 +1,54 @@
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Umbraco.Core;
+
+namespace nuPickers
+{
+    internal class EmbeddedResourceHelper
+    {
+        public static bool ResourceExists(string resource)
+        {
+            if (resource.StartsWith(EmbeddedResource.RootUrl))
+            {
+                resource = "nuPickers.Shared." + resource.TrimStart(EmbeddedResource.RootUrl).Replace("/", ".").TrimEnd(".nu");
+            }
+
+            // get this assembly
+            var assembly = typeof(EmbeddedResourceController).Assembly;
+
+            // find the resource name not case sensitive
+            var resourceName =
+                assembly.GetManifestResourceNames()
+                    .FirstOrDefault(
+                        x => x.ToLower(CultureInfo.InvariantCulture) == resource.ToLower(CultureInfo.InvariantCulture));
+
+            return !string.IsNullOrEmpty(resourceName);
+        }
+
+        public static Stream GetResource(string resource, out string resourceName)
+        {
+            if (resource.StartsWith(EmbeddedResource.RootUrl))
+            {
+                resource = "nuPickers.Shared." + resource.TrimStart(EmbeddedResource.RootUrl).Replace("/", ".").TrimEnd(".nu");
+            }
+
+            // get this assembly
+            var assembly = typeof(EmbeddedResourceController).Assembly;
+
+            // find the resource name not case sensitive
+            resourceName =
+                assembly.GetManifestResourceNames()
+                    .FirstOrDefault(
+                        x => x.ToLower(CultureInfo.InvariantCulture) == resource.ToLower(CultureInfo.InvariantCulture));
+
+            if (resourceName != null)
+            {
+                return assembly.GetManifestResourceStream(resourceName);
+            }
+
+            return null;
+        }
+
+    }
+}

--- a/source/nuPickers/EmbeddedResourceStartup.cs
+++ b/source/nuPickers/EmbeddedResourceStartup.cs
@@ -1,6 +1,5 @@
 ﻿namespace nuPickers
 {
-    using System.Web.Mvc;
     using System.Web.Routing;
     using Umbraco.Core;
 
@@ -9,17 +8,7 @@
         protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
         {
             base.ApplicationStarted(umbracoApplication, applicationContext);
-
-            RouteTable.Routes.MapRoute(
-                name: "nuPickersShared",
-                url: "App_Plugins/nuPickers/Shared/{folder}/{file}",
-                defaults: new
-                {
-                    controller = "EmbeddedResource",
-                    action = "GetSharedResource"
-                },
-                namespaces: new[] { "nuPickers" }
-            );
-        }
+            RouteBuilder.BuildRoutes(RouteTable.Routes);
+        }        
     }
 }

--- a/source/nuPickers/EmbeddedResourceVirtualFile.cs
+++ b/source/nuPickers/EmbeddedResourceVirtualFile.cs
@@ -1,0 +1,37 @@
+﻿using System.IO;
+using System.Web.Hosting;
+using ClientDependency.Core.CompositeFiles;
+
+namespace nuPickers
+{
+    internal class EmbeddedResourceVirtualFile : IVirtualFile
+    {
+        private readonly string _virtualPath;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:System.Web.Hosting.VirtualFile"/> class. 
+        /// </summary>
+        /// <param name="virtualPath">The virtual path to the resource represented by this instance. </param>
+        public EmbeddedResourceVirtualFile(string virtualPath)
+        {
+            _virtualPath = virtualPath;
+        }
+
+        /// <summary>
+        /// When overridden in a derived class, returns a read-only stream to the virtual resource.
+        /// </summary>
+        /// <returns>
+        /// A read-only stream to the virtual file.
+        /// </returns>
+        public Stream Open()
+        {
+            string resourceName;
+            return EmbeddedResourceHelper.GetResource(_virtualPath, out resourceName);
+        }
+
+        public string Path
+        {
+            get { return _virtualPath; }
+        }
+    }
+}

--- a/source/nuPickers/EmbeddedResourceVirtualPathProvider.cs
+++ b/source/nuPickers/EmbeddedResourceVirtualPathProvider.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Web.Hosting;
+using ClientDependency.Core.CompositeFiles;
+
+namespace nuPickers
+{
+    public sealed class EmbeddedResourceVirtualPathProvider : IVirtualFileProvider
+    {
+        public bool FileExists(string virtualPath)
+        {
+            if (!virtualPath.EndsWith(".nu", StringComparison.InvariantCultureIgnoreCase)) return false;
+
+            return EmbeddedResourceHelper.ResourceExists(virtualPath);
+        }
+
+        public IVirtualFile GetFile(string virtualPath)
+        {
+            if (!FileExists(virtualPath)) return null;
+
+            return new EmbeddedResourceVirtualFile(virtualPath);
+        }
+    }
+}

--- a/source/nuPickers/EmbeddedResourceWriter.cs
+++ b/source/nuPickers/EmbeddedResourceWriter.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+using System.Web.Hosting;
+using ClientDependency.Core;
+using ClientDependency.Core.CompositeFiles;
+using ClientDependency.Core.CompositeFiles.Providers;
+
+namespace nuPickers
+{
+    public sealed class EmbeddedResourceWriter : IVirtualFileWriter
+    {
+        public bool WriteToStream(BaseCompositeFileProcessingProvider provider, StreamWriter sw, IVirtualFile vf, ClientDependencyType type, string origUrl, HttpContextBase http)
+        {
+            try
+            {
+                using (var readStream = vf.Open())
+                using (var streamReader = new StreamReader(readStream))
+                {
+                    var output = streamReader.ReadToEnd();
+                    DefaultFileWriter.WriteContentToStream(provider, sw, output, type, http, origUrl);
+                    return true;
+                }
+            }
+            catch (Exception)
+            {
+                //the file must have failed to open
+                return false;
+            }
+        }
+
+        public IVirtualFileProvider FileProvider
+        {
+            get { return new EmbeddedResourceVirtualPathProvider(); }
+        }
+    }
+}

--- a/source/nuPickers/RouteBuilder.cs
+++ b/source/nuPickers/RouteBuilder.cs
@@ -1,0 +1,22 @@
+﻿using System.Web.Mvc;
+using System.Web.Routing;
+
+namespace nuPickers
+{
+    public static class RouteBuilder
+    {
+        public static void BuildRoutes(RouteCollection routes)
+        {
+            routes.MapRoute(
+                name: "nuPickersShared",
+                url: "App_Plugins/nuPickers/Shared/{folder}/{file}.nu",
+                defaults: new
+                {
+                    controller = "EmbeddedResource",
+                    action = "GetSharedResource"
+                },
+                namespaces: new[] { "nuPickers" }
+                );
+        }
+    }
+}

--- a/source/nuPickers/nuPickers.csproj
+++ b/source/nuPickers/nuPickers.csproj
@@ -42,9 +42,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\UmbracoCms.Core.7.1.3\lib\businesslogic.dll</HintPath>
     </Reference>
-    <Reference Include="ClientDependency.Core, Version=1.7.1.2, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ClientDependency.1.7.1.2\lib\ClientDependency.Core.dll</HintPath>
+    <Reference Include="ClientDependency.Core">
+      <HintPath>..\packages\ClientDependency.1.8.2.1\lib\net45\ClientDependency.Core.dll</HintPath>
     </Reference>
     <Reference Include="ClientDependency.Core.Mvc, Version=1.7.0.4, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -143,7 +142,7 @@
       <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.4.0.20710.0\lib\net40\System.Web.Http.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.Mvc.4.0.20710.0\lib\net40\System.Web.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -216,7 +215,11 @@
   <ItemGroup>
     <Compile Include="EmbeddedResource.cs" />
     <Compile Include="EmbeddedResourceController.cs" />
+    <Compile Include="EmbeddedResourceHelper.cs" />
     <Compile Include="EmbeddedResourceStartup.cs" />
+    <Compile Include="EmbeddedResourceVirtualFile.cs" />
+    <Compile Include="EmbeddedResourceVirtualPathProvider.cs" />
+    <Compile Include="EmbeddedResourceWriter.cs" />
     <Compile Include="Helper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PropertyEditors\BasePropertyEditor.cs" />
@@ -269,6 +272,7 @@
     <Compile Include="PickerPropertyValueConverter.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="RouteBuilder.cs" />
     <Compile Include="Shared\DotNetDataSource\DotNetDataSource.cs" />
     <Compile Include="Shared\DotNetDataSource\DotNetDataSourceApiController.cs" />
     <Compile Include="Shared\DotNetDataSource\DotNetDataSourceAttribute.cs" />

--- a/source/nuPickers/nuPickers.csproj
+++ b/source/nuPickers/nuPickers.csproj
@@ -42,8 +42,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\UmbracoCms.Core.7.1.3\lib\businesslogic.dll</HintPath>
     </Reference>
-    <Reference Include="ClientDependency.Core">
-      <HintPath>..\packages\ClientDependency.1.8.2.1\lib\net45\ClientDependency.Core.dll</HintPath>
+    <Reference Include="ClientDependency.Core, Version=1.8.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\ClientDependency.1.8.3\lib\net45\ClientDependency.Core.dll</HintPath>
     </Reference>
     <Reference Include="ClientDependency.Core.Mvc, Version=1.7.0.4, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/source/nuPickers/packages.config
+++ b/source/nuPickers/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AutoMapper" version="3.0.0" targetFramework="net45" />
-  <package id="ClientDependency" version="1.7.1.2" targetFramework="net45" />
+  <package id="ClientDependency" version="1.8.2.1" targetFramework="net45" />
   <package id="ClientDependency-Mvc" version="1.7.0.4" targetFramework="net45" />
   <package id="HtmlAgilityPack" version="1.4.6" targetFramework="net45" />
   <package id="ImageProcessor" version="1.9.0.0" targetFramework="net45" />

--- a/source/nuPickers/packages.config
+++ b/source/nuPickers/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AutoMapper" version="3.0.0" targetFramework="net45" />
-  <package id="ClientDependency" version="1.8.2.1" targetFramework="net45" />
+  <package id="ClientDependency" version="1.8.3" targetFramework="net45" />
   <package id="ClientDependency-Mvc" version="1.7.0.4" targetFramework="net45" />
   <package id="HtmlAgilityPack" version="1.4.6" targetFramework="net45" />
   <package id="ImageProcessor" version="1.9.0.0" targetFramework="net45" />

--- a/source/nuWebTestSite/App_Start/RouteConfig.cs
+++ b/source/nuWebTestSite/App_Start/RouteConfig.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Mvc;
+using System.Web.Routing;
+using nuPickers;
+
+namespace nuWebTestSite
+{
+    public class RouteConfig
+    {
+        public static void RegisterRoutes(RouteCollection routes)
+        {
+            routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
+
+            RouteBuilder.BuildRoutes(routes);
+
+            routes.MapRoute(
+                name: "Default",
+                url: "{controller}/{action}/{id}",
+                defaults: new { controller = "Home", action = "Index", id = UrlParameter.Optional }
+            );
+        }
+    }
+}

--- a/source/nuWebTestSite/Controllers/HomeController.cs
+++ b/source/nuWebTestSite/Controllers/HomeController.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Mvc;
+
+namespace nuWebTestSite.Controllers
+{
+    public class HomeController : Controller
+    {
+        // GET: Home
+        public ActionResult Index()
+        {
+            return View();
+        }
+    }
+}

--- a/source/nuWebTestSite/Global.asax
+++ b/source/nuWebTestSite/Global.asax
@@ -1,0 +1,1 @@
+﻿<%@ Application Codebehind="Global.asax.cs" Inherits="nuWebTestSite.MvcApplication" Language="C#" %>

--- a/source/nuWebTestSite/Global.asax.cs
+++ b/source/nuWebTestSite/Global.asax.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Hosting;
+using System.Web.Mvc;
+using System.Web.Routing;
+using ClientDependency.Core;
+using ClientDependency.Core.Mvc;
+using Microsoft.Web.Mvc;
+using nuPickers;
+
+namespace nuWebTestSite
+{
+    public class MvcApplication : HttpApplication
+    {
+        protected void Application_Start()
+        {
+            AreaRegistration.RegisterAllAreas();
+            RouteConfig.RegisterRoutes(RouteTable.Routes);
+
+            //an extension method to replace the default razor view engine with the CDF view engine
+            // instead of using the cdf module since this is only for mvc
+            ViewEngines.Engines.ReplaceEngine<FixedRazorViewEngine>(new CdfRazorViewEngine());
+            FileWriters.AddWriterForExtension(".nu", new EmbeddedResourceWriter());
+        }
+    }
+}

--- a/source/nuWebTestSite/Properties/AssemblyInfo.cs
+++ b/source/nuWebTestSite/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("nuWebTestSite")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("nuWebTestSite")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("3b5bd9a9-7411-4a74-a8a3-be3790bac289")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/source/nuWebTestSite/Views/Home/Index.cshtml
+++ b/source/nuWebTestSite/Views/Home/Index.cshtml
@@ -1,0 +1,31 @@
+﻿@using ClientDependency.Core.Mvc
+
+@{
+    Layout = null;
+}
+
+<!DOCTYPE html>
+
+<html>
+<head>
+    <meta name="viewport" content="width=device-width" />
+    <title>Index</title>
+
+    @{
+        Html
+            .RequiresJs("/App_Plugins/nuPickers/Shared/CheckBoxPicker/CheckBoxPickerEditorController.js.nu")
+            .RequiresJs("/App_Plugins/nuPickers/Shared/Editor/EditorResource.js.nu")
+            .RequiresJs("/App_Plugins/nuPickers/Shared/DataSource/DataSourceResource.js.nu")
+            .RequiresJs("/App_Plugins/nuPickers/Shared/RelationMapping/RelationMappingResource.js.nu");
+    }
+
+    @Html.RenderJsHere()
+
+</head>
+<body>
+    <h1>Hello world</h1>
+    <div>
+
+    </div>
+</body>
+</html>

--- a/source/nuWebTestSite/Views/web.config
+++ b/source/nuWebTestSite/Views/web.config
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0"?>
+
+<configuration>
+  <configSections>
+    <sectionGroup name="system.web.webPages.razor" type="System.Web.WebPages.Razor.Configuration.RazorWebSectionGroup, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35">
+      <section name="host" type="System.Web.WebPages.Razor.Configuration.HostSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
+      <section name="pages" type="System.Web.WebPages.Razor.Configuration.RazorPagesSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
+    </sectionGroup>
+  </configSections>
+
+  <system.web.webPages.razor>
+    <host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+    <pages pageBaseType="System.Web.Mvc.WebViewPage">
+      <namespaces>
+        <add namespace="System.Web.Mvc" />
+        <add namespace="System.Web.Mvc.Ajax" />
+        <add namespace="System.Web.Mvc.Html" />
+        <add namespace="System.Web.Routing" />
+        <add namespace="nuWebTestSite" />
+      </namespaces>
+    </pages>
+  </system.web.webPages.razor>
+
+  <appSettings>
+    <add key="webpages:Enabled" value="false" />
+  </appSettings>
+
+  <system.webServer>
+    <handlers>
+      <remove name="BlockViewHandler"/>
+      <add name="BlockViewHandler" path="*" verb="*" preCondition="integratedMode" type="System.Web.HttpNotFoundHandler" />
+    </handlers>
+  </system.webServer>
+</configuration>

--- a/source/nuWebTestSite/Web.Debug.config
+++ b/source/nuWebTestSite/Web.Debug.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/source/nuWebTestSite/Web.Release.config
+++ b/source/nuWebTestSite/Web.Release.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/source/nuWebTestSite/Web.config
+++ b/source/nuWebTestSite/Web.config
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  http://go.microsoft.com/fwlink/?LinkId=301880
+  -->
+<configuration>
+  <configSections>
+    <section name="clientDependency" type="ClientDependency.Core.Config.ClientDependencySection, ClientDependency.Core" requirePermission="false" />
+  </configSections>
+  <appSettings>
+    <add key="webpages:Version" value="3.0.0.0" />
+    <add key="webpages:Enabled" value="false" />
+    <add key="ClientValidationEnabled" value="true" />
+    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+  </appSettings>
+  <system.web>
+    <compilation debug="false" targetFramework="4.5" />
+    <httpRuntime targetFramework="4.5" />
+    <pages>
+      <namespaces>
+        <add namespace="ClientDependency.Core" />
+        <add namespace="ClientDependency.Core.Mvc" />
+      </namespaces>
+    </pages>
+    <httpModules />
+    <httpHandlers>
+      <add verb="GET" path="DependencyHandler.axd" type="ClientDependency.Core.CompositeFiles.CompositeDependencyHandler, ClientDependency.Core " />
+    </httpHandlers>
+  </system.web>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages.Razor" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Razor" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <system.webServer>
+    <validation validateIntegratedModeConfiguration="false" />
+    <modules runAllManagedModulesForAllRequests="true" />
+    <handlers>
+      <remove name="DependencyHandler" />
+      <add name="DependencyHandler" preCondition="integratedMode" verb="GET" path="DependencyHandler.axd" type="ClientDependency.Core.CompositeFiles.CompositeDependencyHandler, ClientDependency.Core " />
+    </handlers>
+  </system.webServer>
+  <clientDependency version="2">
+    <!-- Full config documentation is here: https://github.com/Shazwazza/ClientDependency/wiki/Configuration -->
+  </clientDependency>
+</configuration>

--- a/source/nuWebTestSite/Web.config
+++ b/source/nuWebTestSite/Web.config
@@ -14,15 +14,17 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
   </appSettings>
   <system.web>
-    <compilation debug="false" targetFramework="4.5" />
+    <compilation debug="true" targetFramework="4.5" />
     <httpRuntime targetFramework="4.5" />
     <pages>
       <namespaces>
-        <add namespace="ClientDependency.Core" />
         <add namespace="ClientDependency.Core.Mvc" />
+        <add namespace="ClientDependency.Core" />
       </namespaces>
     </pages>
-    <httpModules />
+    <httpModules>
+      <add name="ClientDependencyModule" type="ClientDependency.Core.Module.ClientDependencyModule, ClientDependency.Core" />
+    </httpModules>
     <httpHandlers>
       <add verb="GET" path="DependencyHandler.axd" type="ClientDependency.Core.CompositeFiles.CompositeDependencyHandler, ClientDependency.Core " />
     </httpHandlers>
@@ -81,13 +83,16 @@
   </runtime>
   <system.webServer>
     <validation validateIntegratedModeConfiguration="false" />
-    <modules runAllManagedModulesForAllRequests="true" />
+    <modules  runAllManagedModulesForAllRequests="true">
+      <remove name="ClientDependencyModule" />
+      <add name="ClientDependencyModule" type="ClientDependency.Core.Module.ClientDependencyModule, ClientDependency.Core" />
+    </modules>
     <handlers>
       <remove name="DependencyHandler" />
       <add name="DependencyHandler" preCondition="integratedMode" verb="GET" path="DependencyHandler.axd" type="ClientDependency.Core.CompositeFiles.CompositeDependencyHandler, ClientDependency.Core " />
     </handlers>
   </system.webServer>
-  <clientDependency version="2">
+  <clientDependency version="1">
     <!-- Full config documentation is here: https://github.com/Shazwazza/ClientDependency/wiki/Configuration -->
   </clientDependency>
 </configuration>

--- a/source/nuWebTestSite/nuWebTestSite.csproj
+++ b/source/nuWebTestSite/nuWebTestSite.csproj
@@ -40,9 +40,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ClientDependency.Core, Version=1.8.2.1, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="ClientDependency.Core, Version=1.8.3.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\ClientDependency.1.8.2.1\lib\net45\ClientDependency.Core.dll</HintPath>
+      <HintPath>..\packages\ClientDependency.1.8.3\lib\net45\ClientDependency.Core.dll</HintPath>
     </Reference>
     <Reference Include="ClientDependency.Core.Mvc">
       <HintPath>..\packages\ClientDependency-Mvc5.1.8.0.0\lib\net45\ClientDependency.Core.Mvc.dll</HintPath>

--- a/source/nuWebTestSite/nuWebTestSite.csproj
+++ b/source/nuWebTestSite/nuWebTestSite.csproj
@@ -1,0 +1,186 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{866E1649-BC20-427C-A00B-6D340639EFEA}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>nuWebTestSite</RootNamespace>
+    <AssemblyName>nuWebTestSite</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="ClientDependency.Core, Version=1.8.2.1, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\ClientDependency.1.8.2.1\lib\net45\ClientDependency.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="ClientDependency.Core.Mvc">
+      <HintPath>..\packages\ClientDependency-Mvc5.1.8.0.0\lib\net45\ClientDependency.Core.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.WebHelpers.3.2.3\lib\net45\Microsoft.Web.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Web.Mvc.FixedDisplayModes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.FixedDisplayModes.1.0.0\lib\net40\Microsoft.Web.Mvc.FixedDisplayModes.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Mvc, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.2\lib\net45\System.Web.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+    <Reference Include="WebMatrix.Data, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.Data.3.2.3\lib\net45\WebMatrix.Data.dll</HintPath>
+    </Reference>
+    <Reference Include="WebMatrix.WebData, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.WebData.3.2.3\lib\net45\WebMatrix.WebData.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Global.asax" />
+    <Content Include="Web.config">
+      <SubType>Designer</SubType>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="App_Start\RouteConfig.cs" />
+    <Compile Include="Controllers\HomeController.cs" />
+    <Compile Include="Global.asax.cs">
+      <DependentUpon>Global.asax</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\web.config" />
+    <Content Include="packages.config" />
+    <Content Include="Views\Home\Index.cshtml" />
+    <None Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+    <None Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="App_Data\" />
+    <Folder Include="Models\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\nuPickers\nuPickers.csproj">
+      <Project>{fb665b93-6d85-4040-ab20-003b728e3aca}</Project>
+      <Name>nuPickers</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>4698</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:4698/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/source/nuWebTestSite/packages.config
+++ b/source/nuWebTestSite/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ClientDependency" version="1.8.2.1" targetFramework="net45" />
+  <package id="ClientDependency" version="1.8.3" targetFramework="net45" />
   <package id="ClientDependency-Mvc5" version="1.8.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />

--- a/source/nuWebTestSite/packages.config
+++ b/source/nuWebTestSite/packages.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="ClientDependency" version="1.8.2.1" targetFramework="net45" />
+  <package id="ClientDependency-Mvc5" version="1.8.0.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Mvc" version="5.2.2" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebHelpers" version="3.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages.Data" version="3.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages.WebData" version="3.2.3" targetFramework="net45" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
This PR does the following:

* Allows nuPickers to keep using embedded resources for js/css so you can ship with a single file (assembly)
* Updates to latest CDF which is required with support for the new `IVirtualFileWriter` (etc... classes)
* Adds a very simple test web project to demonstrate the implementation of the `IVirtualFileWriter`
    * The modules section in the web.config must have runAllManagedModulesForAllRequests="true" - which currently is also true in the umbraco core. Without this the *.nu file path will not route when in debug mode
    * To see the JS requests being made in the demo web project you'll need to see them with chrome dev tools

This PR does not actually update all of the css/js resources for the property editors to support this, you'll have to manually do that by changing the PropertyEditorAsset for all JS/CSS files to be suffixed with a ".nu" file extension. For example, the following:

    [PropertyEditorAsset(ClientDependencyType.Javascript, EmbeddedResource.RootUrl + "Editor/EditorResource.js")]

would need to be changed to:

    [PropertyEditorAsset(ClientDependencyType.Javascript, EmbeddedResource.RootUrl + "Editor/EditorResource.js.nu")]

This PR also does not wire up the Umbraco startup handlers, currently the test website on startup needs to create a custom route using the nupickers code:

     RouteBuilder.BuildRoutes(routes);

This would need to be added to an umbraco startup handler to handle the ".nu" web requests when in debug mode.