### PR TITLE
Fix for issue #98

### DIFF
--- a/source/nuPickers/Shared/LuceneDataSource/LuceneDataSourceApiController.cs
+++ b/source/nuPickers/Shared/LuceneDataSource/LuceneDataSourceApiController.cs
@@ -17,7 +17,7 @@ namespace nuPickers.Shared.LuceneDataSource
     {
         public IEnumerable<object> GetExamineSearchers()
         {
-            return Examine.ExamineManager.Instance.SearchProviderCollection.Cast<UmbracoExamineSearcher>().Select(x => x.Name);            
+            return Examine.ExamineManager.Instance.SearchProviderCollection.OfType<UmbracoExamineSearcher>().Select(x => x.Name);            
         }
 
         [HttpPost]


### PR DESCRIPTION
The nuPicker code didn't handle the fact that non-UmbracoExamine Searchers could exist. This update should help fix that.

https://github.com/uComponents/nuPickers/issues/98