### PR TITLE
Allow for the pickers to be used in custom dashboards

### DIFF
--- a/source/nuPickers/Shared/DataSource/DataSourceResource.js
+++ b/source/nuPickers/Shared/DataSource/DataSourceResource.js
@@ -7,14 +7,22 @@ angular.module('umbraco.resources')
             return {
 
                 getEditorDataItems: function (model, typeahead) {
+                    
+                    var parentId = 0;
+                    var currentId = 0;
+		    
+                    if (editorState.current) {
+                        currentId = editorState.current.id;
+			            parentId = editorState.current.parentId;
+                    }
 
                     // returns [{"key":"","label":""},{"key":"","label":""}...]
                     return $http({
                         method: 'POST',
                         url: 'backoffice/nuPickers/' + model.config.dataSource.apiController + '/GetEditorDataItems',
                         params: {
-                            'currentId': editorState.current.id,
-                            'parentId': editorState.current.parentId,
+                            'currentId': currentId,
+                            'parentId': parentId,
                             'propertyAlias': model.alias
                         },
                         data: {


### PR DESCRIPTION
The current setup for nupickers does not allow it to exist outside of the current page context. All that needs to happen is a value needs to be passed for the currentId and parentId if editorstate is null.