### PR TITLE
Return Parent ID if the currentId =  0

### DIFF
--- a/source/nuPickers/Shared/DotNetDataSource/DotNetDataSourceApiController.cs
+++ b/source/nuPickers/Shared/DotNetDataSource/DotNetDataSourceApiController.cs
@@ -85,7 +85,8 @@ namespace nuPickers.Shared.DotNetDataSource
         [HttpPost]
         public IEnumerable<EditorDataItem> GetEditorDataItems([FromUri] int currentId, [FromUri] int parentId, [FromUri] string propertyAlias, [FromBody] dynamic data)
         {
-            int contextId = currentId;
+            
+            int contextId = currentId==0?parentId:currentId;
 
             DotNetDataSource dotNetDataSource = ((JObject)data.config.dataSource).ToObject<DotNetDataSource>();
             dotNetDataSource.Typeahead = (string)data.typeahead;


### PR DESCRIPTION
This is useful if you creating new content item and you need information about the parent.
