### PR TITLE
added new interface for DotNetDataSource to get extra param "parentId"

### DIFF
--- a/source/nuPickers/Shared/DotNetDataSource/DotNetDataSource.cs
+++ b/source/nuPickers/Shared/DotNetDataSource/DotNetDataSource.cs
@@ -21,7 +21,7 @@ namespace nuPickers.Shared.DotNetDataSource
         [DefaultValue(false)]
         internal bool HandledTypeahead { get; set; }
 
-        public IEnumerable<EditorDataItem> GetEditorDataItems(int contextId)
+        public IEnumerable<EditorDataItem> GetEditorDataItems(int contextId, int parentId)
         {
             IEnumerable<EditorDataItem> editorDataItems = Enumerable.Empty<EditorDataItem>();
 
@@ -55,9 +55,11 @@ namespace nuPickers.Shared.DotNetDataSource
                     }
                 }
 
-                editorDataItems = ((IDotNetDataSource)dotNetDataSource)
-                                            .GetEditorDataItems(contextId)
-                                            .Select(x => new EditorDataItem() { Key = x.Key, Label = x.Value });
+                var editorKeyPairValues = dotNetDataSource is IDotNetDataSource
+                    ? ((IDotNetDataSource) dotNetDataSource).GetEditorDataItems(contextId)
+                    : ((IDotNetDataSourceV2) dotNetDataSource).GetEditorDataItems(contextId, parentId);
+
+                editorDataItems = editorKeyPairValues.Select(x => new EditorDataItem() { Key = x.Key, Label = x.Value });
             }
 
             return editorDataItems;

--- a/source/nuPickers/Shared/DotNetDataSource/DotNetDataSourceApiController.cs
+++ b/source/nuPickers/Shared/DotNetDataSource/DotNetDataSourceApiController.cs
@@ -27,7 +27,8 @@ namespace nuPickers.Shared.DotNetDataSource
 
                 if (assembly != null)
                 {
-                    if (assembly.GetLoadableTypes().Any(x => typeof(IDotNetDataSource).IsAssignableFrom(x)))
+                    if (assembly.GetLoadableTypes().Any(x => typeof(IDotNetDataSource).IsAssignableFrom(x) || 
+                                                             typeof(IDotNetDataSourceV2).IsAssignableFrom(x)))
                     {
                         assemblyNames.Add(assemblyName);
                     }
@@ -45,7 +46,8 @@ namespace nuPickers.Shared.DotNetDataSource
             {
                 return assembly
                         .GetLoadableTypes()
-                        .Where(x => typeof(IDotNetDataSource).IsAssignableFrom(x))
+                        .Where(x => typeof(IDotNetDataSource).IsAssignableFrom(x) ||
+                                    typeof(IDotNetDataSourceV2).IsAssignableFrom(x))
                         .Select(x => x.FullName);
             }
             
@@ -90,7 +92,7 @@ namespace nuPickers.Shared.DotNetDataSource
             DotNetDataSource dotNetDataSource = ((JObject)data.config.dataSource).ToObject<DotNetDataSource>();
             dotNetDataSource.Typeahead = (string)data.typeahead;
 
-            IEnumerable<EditorDataItem> editorDataItems = dotNetDataSource.GetEditorDataItems(contextId).ToList();
+            IEnumerable<EditorDataItem> editorDataItems = dotNetDataSource.GetEditorDataItems(contextId, parentId).ToList();
 
             CustomLabel customLabel = new CustomLabel((string)data.config.customLabel, contextId, propertyAlias);
 

--- a/source/nuPickers/Shared/DotNetDataSource/IDotNetDataSourceV2.cs
+++ b/source/nuPickers/Shared/DotNetDataSource/IDotNetDataSourceV2.cs
@@ -3,12 +3,12 @@ namespace nuPickers.Shared.DotNetDataSource
 {
     using System.Collections.Generic;
 
-    public interface IDotNetDataSourceV2
+    public interface IDotNetDataSource
     {
         /// <returns>
         /// 1st string is the key
         /// 2nd string is the label
         /// </returns>
-        IEnumerable<KeyValuePair<string, string>> GetEditorDataItems(int contextId, int parentId);
+        IEnumerable<KeyValuePair<string, string>> GetEditorDataItems(int contextId);
     }
 }

--- a/source/nuPickers/nuPickers.csproj
+++ b/source/nuPickers/nuPickers.csproj
@@ -287,6 +287,7 @@
     <Compile Include="Shared\DotNetDataSource\DotNetDataSourceApiController.cs" />
     <Compile Include="Shared\DotNetDataSource\DotNetDataSourceAttribute.cs" />
     <Compile Include="Shared\DotNetDataSource\DotNetDataSourceProperty.cs" />
+    <Compile Include="Shared\DotNetDataSource\IDotNetDataSourceV2.cs" />
     <Compile Include="Shared\DotNetDataSource\IDotNetDataSource.cs" />
     <Compile Include="Shared\DotNetDataSource\IDotNetDataSourceTypeahead.cs" />
     <Compile Include="Shared\EnumDataSource\EnumExtensions.cs" />


### PR DESCRIPTION
I added new param "parantId" to the DotNetDataSource interface to be able to provide data based on the parentId of the document type. To not break others projects building I added a V2 interface with the change. Please verify if it could've been done differently I suggest any changes.