### PR TITLE
Fixed consecutive <ng-include ... /> bug

### DIFF
--- a/source/nuPickers/Shared/PagedListPicker/PagedListPickerEditor.html
+++ b/source/nuPickers/Shared/PagedListPicker/PagedListPickerEditor.html
@@ -9,7 +9,7 @@
 
 
         <div class="selectable-and-pager">
-            <ng-include src="'/App_Plugins/nuPickers/Shared/ListPicker/ListPickerSelectablePartial.html'" />
+            <ng-include src="'/App_Plugins/nuPickers/Shared/ListPicker/ListPickerSelectablePartial.html'" ></ng-include>
 
             <ul class="paging-buttons">
                 <li ng-repeat="page in pages" ng-class="{active:page == currentPage}">
@@ -18,7 +18,7 @@
             </ul>
         </div>
 
-        <ng-include src="'/App_Plugins/nuPickers/Shared/ListPicker/ListPickerSelectedPartial.html'" />
+        <ng-include src="'/App_Plugins/nuPickers/Shared/ListPicker/ListPickerSelectedPartial.html'" ></ng-include>
 
     </div>
 </div>

--- a/source/nuPickers/Shared/PrefetchListPicker/PrefetchListPickerEditor.html
+++ b/source/nuPickers/Shared/PrefetchListPicker/PrefetchListPickerEditor.html
@@ -19,8 +19,8 @@
                    nu-enter-key="enterKey()" />
         </div>
 
-        <ng-include src="'/App_Plugins/nuPickers/Shared/ListPicker/ListPickerSelectablePartial.html'" />
-        <ng-include src="'/App_Plugins/nuPickers/Shared/ListPicker/ListPickerSelectedPartial.html'" />
+        <ng-include src="'/App_Plugins/nuPickers/Shared/ListPicker/ListPickerSelectablePartial.html'"></ng-include>
+        <ng-include src="'/App_Plugins/nuPickers/Shared/ListPicker/ListPickerSelectedPartial.html'"></ng-include>
 
     </div>
 </div>

--- a/source/nuPickers/Shared/TypeaheadListPicker/TypeaheadListPickerEditor.html
+++ b/source/nuPickers/Shared/TypeaheadListPicker/TypeaheadListPickerEditor.html
@@ -20,8 +20,8 @@
                    <!--nu-blur="clear()" />-->
         </div>
 
-        <ng-include src="'/App_Plugins/nuPickers/Shared/ListPicker/ListPickerSelectablePartial.html'" />
-        <ng-include src="'/App_Plugins/nuPickers/Shared/ListPicker/ListPickerSelectedPartial.html'" />
+        <ng-include src="'/App_Plugins/nuPickers/Shared/ListPicker/ListPickerSelectablePartial.html'" ></ng-include>
+        <ng-include src="'/App_Plugins/nuPickers/Shared/ListPicker/ListPickerSelectedPartial.html'" ></ng-include>
 
     </div>
 </div>


### PR DESCRIPTION
Fixed error where two consecutive `<ng-include ... />` elements that were not closed with explicit `</ng-include>` tags would cause the 2nd `<ng-include ... />` to silently disappear. This was breaking my Enum PrefetchListPickers on an Umbraco 7.4.3 site after upgrading from nuPickers 1.5.3 to 1.7.0.

I apologize if this pull request doesn't follow the correct protocol for contributing to nuPickers. Please let me know if you need me to modify anything.

This is the stackoverflow thread that helped me figure it out:
https://stackoverflow.com/questions/25217260/using-nginclude-multiple-times-in-angularjs