### PR TITLE
Fix issue where csv data could be lost

### DIFF
--- a/source/nuPickers/Shared/ListPicker/ListPickerEditorController.js
+++ b/source/nuPickers/Shared/ListPicker/ListPickerEditorController.js
@@ -12,6 +12,13 @@ angular
             // array of option objects, for the selected list
             $scope.selectedOptions = []; // [{"key":"","label":""}...]
 
+            var ids = $scope.model.value.split(',');
+
+            // loop over ids and create object, add to final
+            $scope.selectedOptions = ids.map(function (id) {
+                return { 'key': id, 'label': 'loading ...' }
+            });
+
             // http://api.jqueryui.com/sortable/
             $scope.sortableConfiguration = { axis: 'y' };
 


### PR DESCRIPTION
If the user presses save/publish quickly it is possible to lose the
picker value when using csv. This fix preloads the list with the csv
values so they are not lost. This issue is most likely to occur when the
list stores a long list of values.