### PR TITLE
The enabled property was commented out in EnumDataSource.cs

### DIFF
--- a/source/nuPickers/Shared/EnumDataSource/EnumDataSource.cs
+++ b/source/nuPickers/Shared/EnumDataSource/EnumDataSource.cs
@@ -45,7 +45,8 @@
             {
                 FieldInfo fieldInfo = enumType.GetField(enumItemName);
                 string key = enumItemName;
-                string label = enumItemName;                
+                string label = enumItemName;
+	            bool enabled = true;
 
                 foreach(CustomAttributeData customAttributeData in CustomAttributeData.GetCustomAttributes(fieldInfo))
                 {
@@ -66,14 +67,15 @@
                                     break;
 
                                 case "Enabled":
-                                    //enabled = (bool)customAttributeNamedArguement.TypedValue.Value;
+                                    enabled = (bool)customAttributeNamedArguement.TypedValue.Value;
                                     break;
                             }
                         }
                     }
                 }
 
-                editorDataItems.Add(new EditorDataItem() { Key = key, Label = label });
+				if(enabled)
+					editorDataItems.Add(new EditorDataItem() { Key = key, Label = label });
             }
 
             return editorDataItems;


### PR DESCRIPTION
The Enabled property was commented out, but I would imagine intended. Adding it back in, with relevant handling, resolves the issue.

The only concern I have about this is why it was commented out. It might make sense to change the code to: `enabled = customAttributeNamedArguement.TypedValue.Value as bool? ?? true;` to be safe.